### PR TITLE
Explicitly add shell command

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,7 +23,7 @@ main() {
   [[ $(id -u) -ne 0 ]] && $WERCKER_STEP_ROOT/addKey.sh $HOME $USER $ssh_key_path $WERCKER_ADD_SSH_KEY_HOST
 
   # Also add it for root
-  sudo $WERCKER_STEP_ROOT/addKey.sh /root root $ssh_key_path $WERCKER_ADD_SSH_KEY_HOST
+  sudo /bin/sh $WERCKER_STEP_ROOT/addKey.sh /root root $ssh_key_path $WERCKER_ADD_SSH_KEY_HOST
 }
 
 main;

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: add-ssh-key
-version: 1.0.3
+version: 1.0.4
 description: |
   Wercker allows you to generate SSH keys and expose them as via
   environment variables to your build or deployment pipeline.


### PR DESCRIPTION
In my environment, the result was as follows.
I will send a correction plan.

Please review.

```
export WERCKER_STEP_ROOT="/pipeline/add-ssh-key-aaa074bb-be69-4c19-93bc-1ad1083b283e"
export WERCKER_STEP_ID="add-ssh-key-aaa074bb-be69-4c19-93bc-1ad1083b283e"
export WERCKER_STEP_OWNER="wercker"
export WERCKER_STEP_NAME="add-ssh-key"
export WERCKER_REPORT_NUMBERS_FILE="/report/add-ssh-key-aaa074bb-be69-4c19-93bc-1ad1083b283e/numbers.ini"
export WERCKER_REPORT_MESSAGE_FILE="/report/add-ssh-key-aaa074bb-be69-4c19-93bc-1ad1083b283e/message.txt"
export WERCKER_REPORT_ARTIFACTS_DIR="/report/add-ssh-key-aaa074bb-be69-4c19-93bc-1ad1083b283e/artifacts"
export WERCKER_ADD_SSH_KEY_HOST="github.com"
export WERCKER_ADD_SSH_KEY_KEYNAME="MYPACKAGE_KEY"
source "/pipeline/add-ssh-key-aaa074bb-be69-4c19-93bc-1ad1083b283e/run.sh" < /dev/null
/bin/sh: /pipeline/add-ssh-key-aaa074bb-be69-4c19-93bc-1ad1083b283e/run.sh: line 29: /pipeline/add-ssh-key-aaa074bb-be69-4c19-93bc-1ad1083b283e/addKey.sh: not found
```