### PR TITLE
Resolve #16 - use /bin/sh not /bin/bash.

### DIFF
--- a/addKey.sh
+++ b/addKey.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ ! -d "$1/.ssh" ]; then
    mkdir -p "$1/.ssh"

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 validate_key() {
   local private_key=$1;


### PR DESCRIPTION
Resolve #16.  Using box that doesn't include /bin/bash results in failure.  Switch to /bin/sh.