### PR TITLE
Issue 1561 - improve error reporting when add-ssh-key fails 

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,17 @@ validate_key() {
   local private_key=$1;
 
   if [ -z "$private_key" ]; then
-    fail "Private key not found. Do not prepend the keyname with a dollar sign and do not use _PRIVATE at the end.";
+    if [ "${#WERCKER_ADD_SSH_KEY_KEYNAME}" -eq 0 ] ; then
+      message="Private key not found. The keyname was blank, may indicate dollar sign prepended to the keyname."
+    else
+      tmp=`echo "$WERCKER_ADD_SSH_KEY_KEYNAME" | sed -e 's/_PRIVATE$//'`
+      if [ "$tmp" != "$WERCKER_ADD_SSH_KEY_KEYNAME" ] ; then
+        message="Private key not found. The keyname should not have _PRIVATE at the end."
+      else
+        message="Private key not found. Be sure to create an environment variable named ${WERCKER_ADD_SSH_KEY_KEYNAME}_PRIVATE (X_${WERCKER_ADD_SSH_KEY_KEYNAME}_PRIVATE if using the CLI) containing the SSH private key."
+      fi
+    fi
+    fail "$message"
   fi
 }
 

--- a/run.sh
+++ b/run.sh
@@ -4,11 +4,11 @@ validate_key() {
   local private_key=$1;
 
   if [ -z "$private_key" ]; then
-    if [ "${#WERCKER_ADD_SSH_KEY_KEYNAME}" -eq 0 ] ; then
+    if [ -z "${WERCKER_ADD_SSH_KEY_KEYNAME}" ] ; then
       message="Private key not found. The keyname was blank, may indicate dollar sign prepended to the keyname."
     else
-      tmp=`echo "$WERCKER_ADD_SSH_KEY_KEYNAME" | sed -e 's/_PRIVATE$//'`
-      if [ "$tmp" != "$WERCKER_ADD_SSH_KEY_KEYNAME" ] ; then
+      tmp=$(echo "$WERCKER_ADD_SSH_KEY_KEYNAME" | sed -e 's/.*\(_PRIVATE\)$/\1/')
+      if [ "$tmp" = "_PRIVATE" ] ; then
         message="Private key not found. The keyname should not have _PRIVATE at the end."
       else
         message="Private key not found. Be sure to create an environment variable named ${WERCKER_ADD_SSH_KEY_KEYNAME}_PRIVATE (X_${WERCKER_ADD_SSH_KEY_KEYNAME}_PRIVATE if using the CLI) containing the SSH private key."


### PR DESCRIPTION
[Issue: 1561](https://github.com/wercker/backlog/issues/1561)

When add-ssh-key fails to create a key, the message is correct in spirit, but backwards in substance.

This change attempts to tell the user what might have gone wrong. If they had prepended a dollar sign to their keyname, this would likely result in an empty keyname. If they had appended _PRIVATE to the end of keyname, an explanation about that is given.

But otherwise the error message explains that the environment variable SHOULD end with _PRIVATE and, if using the CLI from the command line, should begin with X_.

Other parts of issue 1561 are being/have been addressed elsewhere - doc by @ljamen and the /bin/sh header by @gilbode.